### PR TITLE
Issue with email text box on sign up page

### DIFF
--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -25,7 +25,7 @@ export default class SignUp extends Component {
   }
 
   passwordSignUpChangedHandler = (event) => {
-    this.state.emailAddressSignup = event.target.value
+    this.state.passwordSignup = event.target.value
     this.setState(
       { passwordSignup: event.target.value }
     )


### PR DESCRIPTION
Fixed issue: text previously entered in email text box is being over written when entering text to create password.